### PR TITLE
SML compatibility

### DIFF
--- a/Classes/FriendlyHUD.uc
+++ b/Classes/FriendlyHUD.uc
@@ -1,0 +1,429 @@
+class FriendlyHUD extends Info;
+
+// Server-only
+var FriendlyHUDCDCompatController CDCompat;
+
+// Replicated
+var FriendlyHUDReplicationInfo RepInfo;
+var bool UMLoaded, CDReadyEnabled;
+
+// Client-only
+var KFPlayerController KFPC;
+var KFGFxHudWrapper HUD;
+var FriendlyHUDInteraction FHUDInteraction;
+var FriendlyHUDConfig HUDConfig;
+
+var bool ForceShowAsFriend;
+var int PriorityCount;
+
+struct ClikKeyModifiers
+{
+    var bool Ctrl;
+    var bool Alt;
+    var bool Shift;
+};
+
+var GFxClikWidget HUDChatInputField, PartyChatInputField;
+var const ClikKeyModifiers UnsetKeyModifiers;
+var ClikKeyModifiers KeyModifiers;
+
+const HelpURL = "https://steamcommunity.com/sharedfiles/filedetails/?id=1827646464";
+const WhatsNewURL = "https://steamcommunity.com/sharedfiles/filedetails/?id=1871444075";
+const GFxListenerPriority = 80000;
+
+replication
+{
+    if (bNetDirty)
+        RepInfo, UMLoaded, CDReadyEnabled;
+}
+
+simulated event PostBeginPlay()
+{
+    super.PostBeginPlay();
+
+    if (bDeleteMe) return;
+
+    `Log("[FriendlyHUD] Loaded mutator");
+
+    if (Role == ROLE_Authority)
+    {
+        UMLoaded = IsUMLoaded();
+
+        RepInfo = Spawn(class'FriendlyHUDReplicationInfo', Self);
+        RepInfo.FHUD = Self;
+        RepInfo.HUDConfig = HUDConfig;
+
+        if (!IsSMLUsed())
+        {
+            CDCompat = Spawn(class'FriendlyHUDCDCompatController', Self);
+            CDCompat.FHUD = Self;
+        }
+
+        SetTimer(2.f, true, nameof(CheckBots));
+    }
+
+    if (WorldInfo.NetMode != NM_DedicatedServer)
+    {
+        InitializeHUD();
+    }
+}
+
+simulated function bool IsSMLUsed()
+{
+    local AccessControl AC;
+
+    // cannot check by accessing 'WorldInfo.Game.AccessControl'
+    // because at this moment it's not initialized yet
+    foreach WorldInfo.DynamicActors(class'AccessControl', AC)
+        if (PathName(AC.class) ~= "SML.SafeMutLoader")
+            return true;
+
+    return false;
+}
+
+simulated event Destroyed()
+{
+    if (WorldInfo.NetMode != NM_DedicatedServer)
+    {
+        KFPC.ConsoleCommand("exec cfg/OnUnloadFHUD.cfg", false);
+    }
+
+    super.Destroyed();
+}
+
+simulated function InitializeHUD()
+{
+    `Log("[FriendlyHUD] Initializing");
+
+    KFPC = KFPlayerController(GetALocalPlayerController());
+
+    if (KFPC == None || RepInfo == None)
+    {
+        SetTimer(0.5f, false, nameof(InitializeHUD));
+        return;
+    }
+
+    `Log("[FriendlyHUD] Found KFPC");
+
+    // Initialize the HUD configuration
+    HUDConfig = new (KFPC) class'FriendlyHUDConfig';
+    HUDConfig.FHUD = Self;
+    HUDConfig.KFPlayerOwner = KFPC;
+    KFPC.Interactions.AddItem(HUDConfig);
+    HUDConfig.Initialized();
+
+    // Give a chance for other mutators to initialize
+    SetTimer(2.f, false, nameof(InitializeDeferred));
+}
+
+simulated function InitializeDeferred()
+{
+    HUD = KFGFxHudWrapper(KFPC.myHUD);
+    if (HUD == None)
+    {
+        `Log("[FriendlyHUD] Incompatible HUD detected; aborting.");
+        return;
+    }
+
+    // Initialize the HUD interaction
+    FHUDInteraction = new (KFPC) class'FriendlyHUDInteraction';
+    FHUDInteraction.FHUD = Self;
+    FHUDInteraction.KFPlayerOwner = KFPC;
+    FHUDInteraction.HUD = HUD;
+    FHUDInteraction.HUDConfig = HUDConfig;
+    KFPC.Interactions.InsertItem(0, FHUDInteraction);
+    FHUDInteraction.Initialized();
+    HUDConfig.FHUDInteraction = FHUDInteraction;
+
+    InitializePartyChatHook();
+    InitializeHUDChatHook();
+    InitializeCompat();
+
+    if (IsUMLoaded())
+    {
+        // Defer the printing because we want our message to show up last
+        SetTimer(1.f, false, nameof(PrintNotification));
+    }
+    else
+    {
+        PrintNotification();
+    }
+
+    KFPC.ConsoleCommand("exec cfg/OnLoadFHUD.cfg", false);
+
+    `Log("[FriendlyHUD] Initialized");
+}
+
+simulated function bool IsUMLoaded()
+{
+    local Mutator Mut;
+
+    if (Role != ROLE_Authority)
+    {
+        return UMLoaded;
+    }
+
+    for (Mut = WorldInfo.Game.BaseMutator; Mut != None; Mut = Mut.NextMutator)
+    {
+        if (PathName(Mut.class) ~= "UnofficialMod.UnofficialModMut") return true;
+    }
+
+    return false;
+}
+
+simulated function InitializeCompat()
+{
+    local UMCompatInteraction UMInteraction;
+
+    if (!IsUMLoaded()) return;
+
+    `Log("[FriendlyHUD] UnofficialMod detected");
+
+    HUDConfig.InitUMCompat();
+
+    UMInteraction = new (KFPC) class'UMCompatInteraction';
+    UMInteraction.KFPlayerOwner = KFPC;
+    UMInteraction.HUD = HUD;
+    UMInteraction.HUDConfig = HUDConfig;
+    KFPC.Interactions.AddItem(UMInteraction);
+    UMInteraction.Initialized();
+}
+
+simulated delegate OnHUDChatInputKeyDown(GFxClikWidget.EventData Data)
+{
+    if (OnChatKeyDown(HUDChatInputField, Data))
+    {
+        // "Enter" doesn't do anything when it gets pressed too quickly
+        // after opening the chat, so we close it here just in case
+        HUD.HUDMovie.HudChatBox.ClearAndCloseChat();
+    }
+}
+
+simulated delegate OnPartyChatInputKeyDown(GFxClikWidget.EventData Data)
+{
+    OnChatKeyDown(PartyChatInputField, Data);
+}
+
+simulated delegate OnChatFocusIn(GFxClikWidget.EventData Data)
+{
+    KeyModifiers = UnsetKeyModifiers;
+}
+
+simulated delegate OnChatFocusOut(GFxClikWidget.EventData Data)
+{
+    KeyModifiers = UnsetKeyModifiers;
+}
+
+simulated function bool OnChatKeyDown(GFxClikWidget InputField, GFxClikWidget.EventData Data)
+{
+    local GFXObject InputDetails;
+    local int KeyCode;
+    local string EventType;
+    local string KeyEvent;
+    local string Text;
+    local OnlineSubsystem OS;
+    `if(`isdefined(debug))
+    local array<GFxMoviePlayer.ASValue> Params;
+    `endif
+
+    OS = class'GameEngine'.static.GetOnlineSubsystem();
+
+    InputDetails = Data._this.GetObject("details");
+    KeyCode = InputDetails.GetInt("code");
+    EventType = InputDetails.GetString("type");
+    KeyEvent = InputDetails.GetString("value");
+
+    if (EventType != "key") return false;
+
+    `if(`isdefined(debug))
+    `Log("[FriendlyHUD] OnKeyDown:" @ Data._this.Invoke("toString", Params).s);
+    `endif
+
+    // CTRL
+    if (KeyCode == 17)
+    {
+        KeyModifiers.Ctrl = KeyEvent != "keyUp";
+        return false;
+    }
+
+    // ALT
+    if (KeyCode == 18)
+    {
+        KeyModifiers.Alt = KeyEvent != "keyUp";
+        return false;
+    }
+
+    // SHIFT
+    if (KeyCode == 16)
+    {
+        KeyModifiers.Shift = KeyEvent != "keyUp";
+        return false;
+    }
+
+    // Enter
+    // Note: the "keyHold" event gets triggered when the chat was opened with a key other than "Enter".
+    //       If the chat was opened with "Enter", the event will be "keyDown" instead.
+    if (KeyCode == 13 && (KeyEvent == "keyHold" || KeyEvent == "keyDown"))
+    {
+        Text = InputField.GetText();
+        switch (Locs(Text))
+        {
+            case "!fhudhelp":
+                if (OS == None) return false;
+                OS.OpenURL(HelpURL);
+                break;
+            case "!fhudnews":
+            case "!fhudwhatsnew":
+            case "!fhudchangelog":
+                if (OS == None) return false;
+
+                // Update the changelog version so that we stop nagging the user
+                HUDConfig.UpdateChangeLogVersion();
+
+                OS.OpenURL(WhatsNewURL);
+                break;
+            case "!fhudversion":
+                WriteToChat("[FriendlyHUD]" @ HUDConfig.GetVersionInfo(), "B986E9");
+                break;
+            default:
+                return false;
+        }
+
+        // Clear the field before letting the default event handler process it
+        // This prevents the command from showing up in chat
+        InputField.SetText("");
+
+        return true;
+    }
+
+    return false;
+}
+
+simulated function InitializePartyChatHook()
+{
+    // Retry until the HUD is fully initialized
+    if (KFPC.MyGFxManager == None || KFPC.MyGFxManager.PartyWidget == None || KFPC.MYGFxManager.PartyWidget.PartyChatWidget == None)
+    {
+        `Log("[FriendlyHUD] Failed initializing party chat hook; retrying.");
+        SetTimer(1.f, false, nameof(InitializePartyChatHook));
+        return;
+    }
+
+    // Force the chat to show up in solo
+    KFPC.MyGFxManager.PartyWidget.PartyChatWidget.SetVisible(true);
+
+    PartyChatInputField = GFxClikWidget(KFPC.MyGFxManager.PartyWidget.PartyChatWidget.GetObject("ChatInputField", class'GFxClikWidget'));
+    PartyChatInputField.AddEventListener('CLIK_input', OnPartyChatInputKeyDown, false, GFxListenerPriority, false);
+    PartyChatInputField.AddEventListener('CLIK_focusIn', OnChatFocusIn, false, GFxListenerPriority, false);
+    PartyChatInputField.AddEventListener('CLIK_focusOut', OnChatFocusOut, false, GFxListenerPriority, false);
+
+    `Log("[FriendlyHUD] Initialized party chat hook");
+}
+
+simulated function InitializeHUDChatHook()
+{
+    // Retry until the HUD is fully initialized
+    if (HUD == None || HUD.HUDMovie == None || HUD.HUDMovie.HudChatBox == None)
+    {
+        `if(`isdefined(debug))
+        `Log("[FriendlyHUD] Failed initializing HUD chat hook; retrying.");
+        `endif
+
+        SetTimer(1.f, false, nameof(InitializeHUDChatHook));
+        return;
+    }
+
+    HUDChatInputField = GFxClikWidget(HUD.HUDMovie.HudChatBox.GetObject("ChatInputField", class'GFxClikWidget'));
+    HUDChatInputField.AddEventListener('CLIK_input', OnHUDChatInputKeyDown, false, GFxListenerPriority, false);
+    HUDChatInputField.AddEventListener('CLIK_focusIn', OnChatFocusIn, false, GFxListenerPriority, false);
+    HUDChatInputField.AddEventListener('CLIK_focusOut', OnChatFocusOut, false, GFxListenerPriority, false);
+
+    `Log("[FriendlyHUD] Initialized HUD chat hook");
+}
+
+simulated function WriteToChat(string Message, string HexColor)
+{
+    if (KFPC.MyGFxManager.PartyWidget != None && KFPC.MyGFxManager.PartyWidget.PartyChatWidget != None)
+    {
+        KFPC.MyGFxManager.PartyWidget.PartyChatWidget.AddChatMessage(Message, HexColor);
+    }
+
+    if (HUD != None && HUD.HUDMovie != None && HUD.HUDMovie.HudChatBox != None)
+    {
+        HUD.HUDMovie.HudChatBox.AddChatMessage(Message, HexColor);
+    }
+}
+
+simulated function PrintNotification()
+{
+    if (HUDConfig.ShowHelpNotification)
+    {
+        WriteToChat("[FriendlyHUD] type !FHUDHelp to open the command list.", "B986E9");
+    }
+
+    if (HUDConfig.LastChangeLogVersion < HUDConfig.CurrentVersion)
+    {
+        WriteToChat("[FriendlyHUD] was updated; type !FHUDNews to see the changelog.", "FFFF00");
+    }
+}
+
+simulated function ForceUpdateNameCache()
+{
+    local FriendlyHUDReplicationInfo CurrentRepInfo;
+    local int I;
+
+    CurrentRepInfo = RepInfo;
+    while (CurrentRepInfo != None)
+    {
+        for (I = 0; I < class'FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
+        {
+            if (CurrentRepInfo.KFPRIArray[I] == None) continue;
+            CurrentRepInfo.ShouldUpdateNameArray[I] = 1;
+        }
+        CurrentRepInfo = CurrentRepInfo.NextRepInfo;
+    }
+}
+
+function CheckBots()
+{
+    local KFPawn_Human KFPH;
+
+    foreach WorldInfo.AllPawns(class'KFGame.KFPawn_Human', KFPH)
+    {
+        if (KFAIController(KFPH.Controller) != None && !RepInfo.IsPlayerRegistered(KFPH.Controller))
+        {
+            RepInfo.NotifyLogin(KFPH.Controller);
+        }
+    }
+}
+
+function NotifyLogin(Controller NewPlayer)
+{
+    RepInfo.NotifyLogin(NewPlayer);
+}
+
+function NotifyLogout(Controller Exiting)
+{
+    RepInfo.NotifyLogout(Exiting);
+}
+
+// Used to receive NotifyLogin / NotifyLogout events from SML
+// 'RequestedBy' contains the Controller
+// 'bRequestAlternateLoc' contains the event type:
+// true:  NotifyLogout
+// false: NotifyLogin
+simulated function vector GetTargetLocation(optional actor RequestedBy, optional bool bRequestAlternateLoc)
+{
+    local Controller C;
+    C = Controller(RequestedBy);
+    if (C != None) { bRequestAlternateLoc ? NotifyLogout(C) : NotifyLogin(C); }
+    return Super.GetTargetLocation(RequestedBy, bRequestAlternateLoc);
+}
+
+defaultproperties
+{
+    Role = ROLE_Authority;
+    RemoteRole = ROLE_SimulatedProxy;
+    bAlwaysRelevant = true;
+    PriorityCount = 1;
+}

--- a/Classes/FriendlyHUDCDCompatController.uc
+++ b/Classes/FriendlyHUDCDCompatController.uc
@@ -6,7 +6,7 @@
 class FriendlyHUDCDCompatController extends Mutator
     dependson(FriendlyHUDReplicationInfo);
 
-var FriendlyHUDMutator FHUDMutator;
+var FriendlyHUD FHUD;
 
 function InitMutator(string Options, out string ErrorMessage)
 {
@@ -31,7 +31,7 @@ function Mutate(string Value, PlayerController Sender)
             FHUDSetCDReadyEnabled(Params);
             break;
         case "FHUDSetCDStateReady":
-            FHUDMutator.CDReadyEnabled = true;
+            FHUD.CDReadyEnabled = true;
             FHUDSetCDStateReady(Params);
             break;
         default:
@@ -48,7 +48,7 @@ function FHUDSetCDReadyEnabled(array<string> Params)
         return;
     }
 
-    FHUDMutator.CDReadyEnabled = bool(Params[1]);
+    FHUD.CDReadyEnabled = bool(Params[1]);
 }
 
 function FHUDSetCDStateReady(array<string> Params)
@@ -68,10 +68,10 @@ function FHUDSetCDStateReady(array<string> Params)
     PlayerId = int(Params[1]);
     ReadyState = bool(Params[2]);
 
-    CurrentRepInfo = FHUDMutator.RepInfo;
+    CurrentRepInfo = FHUD.RepInfo;
     while (CurrentRepInfo != None)
     {
-        for (I = 0; I < class'FriendlyHUD.FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
+        for (I = 0; I < class'FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
         {
             KFPRI = CurrentRepInfo.KFPRIArray[I];
             if (KFPRI != None && KFPRI.PlayerID == PlayerId)

--- a/Classes/FriendlyHUDConfig.uc
+++ b/Classes/FriendlyHUDConfig.uc
@@ -164,7 +164,7 @@ var bool DrawDebugLines;
 var bool DrawDebugRatios;
 
 var KFPlayerController KFPlayerOwner;
-var FriendlyHUDMutator FHUDMutator;
+var FriendlyHUD FHUD;
 var FriendlyHUDInteraction FHUDInteraction;
 
 var int CurrentINIVersion;
@@ -192,7 +192,7 @@ function Initialized()
             UpdateInterval = 0.5f;
             SortStrategy = 0;
             SelfSortStrategy = 1;
-            DynamicOpacity = class'FriendlyHUD.FriendlyHUDHelper'.static.MakeCubicInterpCurve(1.f, 1.f, 4.f, 0.f);
+            DynamicOpacity = class'FriendlyHUDHelper'.static.MakeCubicInterpCurve(1.f, 1.f, 4.f, 0.f);
             Opacity = 1.f;
             IconSize = 32.f;
             IconOffset = 0.f;
@@ -230,7 +230,7 @@ function Initialized()
             FriendIconOffsetY = 0.f;
             FriendIconEnabled = true;
 
-            OldBGColor = class'FriendlyHUD.FriendlyHUDHelper'.static.ColorFromString(BGColor);
+            OldBGColor = class'FriendlyHUDHelper'.static.ColorFromString(BGColor);
             ArmorBGColor = OldBGColor;
             HealthBGColor = OldBGColor;
             BGColor = DEPRECATED_ENTRY;
@@ -239,7 +239,7 @@ function Initialized()
             HealthEmptyBGColor = OldBGColor;
 
             // Rename NameColor to TextColor
-            NameColor = class'FriendlyHUD.FriendlyHUDHelper'.static.ColorFromString(TextColor);
+            NameColor = class'FriendlyHUDHelper'.static.ColorFromString(TextColor);
             TextColor = DEPRECATED_ENTRY;
 
             // Rename BuffMarginX to BuffMargin
@@ -306,7 +306,7 @@ function LoadDefaultFHUDConfig()
     IgnoreSelf = true;
     IgnoreDeadTeammates = true;
     MinHealthThreshold = 1.f;
-    DynamicOpacity = class'FriendlyHUD.FriendlyHUDHelper'.static.MakeCubicInterpCurve(1.f, 1.f, 4.f, 0.f);
+    DynamicOpacity = class'FriendlyHUDHelper'.static.MakeCubicInterpCurve(1.f, 1.f, 4.f, 0.f);
     DynamicColorsStrategy = 0;
     DynamicRegenColorsStrategy = 0;
     Opacity = 1.f;
@@ -1008,7 +1008,7 @@ exec function SetFHUDArmorBlockProportions(float Width, optional string Ratios)
             if (TotalWidth <= 0.f) continue;
 
             // If the ratio would end up in an invisible block, ignore it
-            if (Ratio < class'FriendlyHUD.FriendlyHUDInteraction'.const.FLOAT_EPSILON) continue;
+            if (Ratio < class'FriendlyHUDInteraction'.const.FLOAT_EPSILON) continue;
 
             CurrentBlockWidth = Width * Ratio;
             TotalWidth -= CurrentBlockWidth;
@@ -1073,7 +1073,7 @@ exec function SetFHUDHealthBlockProportions(float Width, optional string Ratios)
             if (TotalWidth <= 0.f) continue;
 
             // If the ratio would end up in an invisible block, ignore it
-            if (Ratio < class'FriendlyHUD.FriendlyHUDInteraction'.const.FLOAT_EPSILON) continue;
+            if (Ratio < class'FriendlyHUDInteraction'.const.FLOAT_EPSILON) continue;
 
             CurrentBlockWidth = Width * Ratio;
             TotalWidth -= CurrentBlockWidth;
@@ -1650,13 +1650,13 @@ exec function SetFHUDBlockOutline(float Top, optional float Right = -1.f, option
 
 exec function SetFHUDArmorBlockOutline(float Top, optional float Right = -1.f, optional float Bottom = -1.f, optional float Left = -1.f)
 {
-    ArmorBlockOutline = class'FriendlyHUD.FriendlyHUDHelper'.static.MakeOutline(Top, Right, Bottom, Left);
+    ArmorBlockOutline = class'FriendlyHUDHelper'.static.MakeOutline(Top, Right, Bottom, Left);
     SaveAndUpdate();
 }
 
 exec function SetFHUDHealthBlockOutline(float Top, optional float Right = -1.f, optional float Bottom = -1.f, optional float Left = -1.f)
 {
-    HealthBlockOutline = class'FriendlyHUD.FriendlyHUDHelper'.static.MakeOutline(Top, Right, Bottom, Left);
+    HealthBlockOutline = class'FriendlyHUDHelper'.static.MakeOutline(Top, Right, Bottom, Left);
     SaveAndUpdate();
 }
 
@@ -2016,7 +2016,7 @@ exec function SetFHUDNameTruncationEnabled(bool Value)
 {
     if (Value != NameTruncationEnabled)
     {
-        FHUDMutator.ForceUpdateNameCache();
+        FHUD.ForceUpdateNameCache();
     }
 
     NameTruncationEnabled = Value;
@@ -2078,7 +2078,7 @@ exec function SetFHUDSortStrategy(string Strategy, optional bool Descending = fa
 
 exec function SetFHUDDynamicOpacity(float P1, optional float P0 = 1.f, optional float T0 = 4.f, float T1 = 0.f)
 {
-    DynamicOpacity = class'FriendlyHUD.FriendlyHUDHelper'.static.MakeCubicInterpCurve(P0, P1, T0, T1);
+    DynamicOpacity = class'FriendlyHUDHelper'.static.MakeCubicInterpCurve(P0, P1, T0, T1);
     SaveAndUpdate();
 }
 
@@ -2361,7 +2361,7 @@ function ConsolePrint(coerce string Text)
 
 function InitUMCompat()
 {
-    if (FHUDMutator.IsUMLoaded())
+    if (FHUD.IsUMLoaded())
     {
         // Forcefully disable UM's dart cooldowns
         if (UMCompatEnabled)

--- a/Classes/FriendlyHUDInteraction.uc
+++ b/Classes/FriendlyHUDInteraction.uc
@@ -1,5 +1,5 @@
 class FriendlyHUDInteraction extends Interaction
-    dependson(FriendlyHUDMutator, FriendlyHUDConfig, FriendlyHUDReplicationInfo);
+    dependson(FriendlyHUD, FriendlyHUDConfig, FriendlyHUDReplicationInfo);
 
 struct PlayerItemInfo
 {
@@ -29,7 +29,7 @@ enum EBarType
 var KFGFxHudWrapper HUD;
 var KFPlayerController KFPlayerOwner;
 var FriendlyHUDConfig HUDConfig;
-var FriendlyHUDMutator FHUDMutator;
+var FriendlyHUD FHUD;
 
 // Player list
 var array<PRIEntry> SortedKFPRIArray;
@@ -89,7 +89,7 @@ function FriendlyHUDReplicationLink GetRepLink()
 {
     local FriendlyHUDReplicationLink RepLink;
 
-    foreach KFPlayerOwner.WorldInfo.DynamicActors(class'FriendlyHUD.FriendlyHUDReplicationLink', RepLink)
+    foreach KFPlayerOwner.WorldInfo.DynamicActors(class'FriendlyHUDReplicationLink', RepLink)
     {
         return RepLink;
     }
@@ -129,7 +129,7 @@ exec function DebugFHUDSpawnBot(optional string BotName, optional int PerkIndex,
 
 exec function SetFHUDDebugForceFriend(bool Value)
 {
-    FHUDMutator.ForceShowAsFriend = Value;
+    FHUD.ForceShowAsFriend = Value;
     UpdateRuntimeVars();
 }
 
@@ -526,7 +526,7 @@ function PrintSelfSortStrategyNotification()
     if (`TimerHelper.IsTimerActive(nameof(SelfSortStrategyNotificationTimer), Self)) return;
 
     `TimerHelper.SetTimer(6.f, false, nameof(SelfSortStrategyNotificationTimer), Self);
-    FHUDMutator.WriteToChat("[FriendlyHUD] You can't move yourself in manual mode by default.\nUse 'SetFHUDSelfSortStrategy unset' to disable this behavior.", "FF6400");
+    FHUD.WriteToChat("[FriendlyHUD] You can't move yourself in manual mode by default.\nUse 'SetFHUDSelfSortStrategy unset' to disable this behavior.", "FF6400");
 }
 
 function SelfSortStrategyNotificationTimer() { }
@@ -554,10 +554,10 @@ function UpdateNames()
     local FriendlyHUDReplicationInfo RepInfo;
     local int I;
 
-    RepInfo = FHUDMutator.RepInfo;
+    RepInfo = FHUD.RepInfo;
     while (RepInfo != None)
     {
-        for (I = 0; I < class'FriendlyHUD.FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
+        for (I = 0; I < class'FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
         {
             if (RepInfo.KFPRIArray[I] == None) continue;
 
@@ -582,10 +582,10 @@ function UpdatePRIArray()
     if (HUDConfig.DisableHUD) return;
 
     SortedKFPRIArray.Length = 0;
-    RepInfo = FHUDMutator.RepInfo;
+    RepInfo = FHUD.RepInfo;
     while (RepInfo != None)
     {
-        for (I = 0; I < class'FriendlyHUD.FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
+        for (I = 0; I < class'FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
         {
             if (RepInfo.KFPRIArray[I] == None) continue;
 
@@ -777,7 +777,7 @@ function CachePlayerNames(Canvas Canvas, bool ForceRefresh)
     local FriendlyHUDReplicationInfo RepInfo;
     local int I;
 
-    RepInfo = FHUDMutator.RepInfo;
+    RepInfo = FHUD.RepInfo;
     while (RepInfo != None)
     {
         for (I = 0; I < class'FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
@@ -801,7 +801,7 @@ function CachePlayerNames(Canvas Canvas, bool ForceRefresh)
             NameWidthMax = R.BarWidthMin - R.NameMarginX;
 
             // Subtract the friend icon from the available width for the player name
-            if (HUDConfig.FriendIconEnabled && (RepInfo.IsFriendArray[I] != 0 || FHUDMutator.ForceShowAsFriend))
+            if (HUDConfig.FriendIconEnabled && (RepInfo.IsFriendArray[I] != 0 || FHUD.ForceShowAsFriend))
             {
                 NameWidthMax -= R.FriendIconSize + R.FriendIconGap;
             }
@@ -870,7 +870,7 @@ function UpdateRuntimeVars(optional Canvas Canvas)
     CachedScreenHeight = Canvas.SizeY;
 
     Canvas.Font = class'KFGameEngine'.static.GetKFCanvasFont();
-    R.ResScale = class'FriendlyHUD.FriendlyHUDHelper'.static.GetResolutionScale(Canvas);
+    R.ResScale = class'FriendlyHUDHelper'.static.GetResolutionScale(Canvas);
     R.Scale = R.ResScale * HUDConfig.Scale;
 
     R.NameScale = class'KFGameEngine'.static.GetKFFontScale() * HUDConfig.NameScale * R.Scale;
@@ -1398,7 +1398,7 @@ function bool DrawHealthBarItem(Canvas Canvas, const out PlayerItemInfo ItemInfo
     // If we're in select mode, bypass all visibility checks
     if (ManualModeActive) { }
     // Only apply render restrictions if we don't have a special state
-    else if (PlayerState == PRS_Default || !FHUDMutator.CDReadyEnabled)
+    else if (PlayerState == PRS_Default || !FHUD.CDReadyEnabled)
     {
         // Don't render if CD trader-time only mode is enabled
         if (HUDConfig.CDOnlyTraderTime) return false;
@@ -1488,7 +1488,7 @@ function bool DrawHealthBarItem(Canvas Canvas, const out PlayerItemInfo ItemInfo
     // Draw player name
     SetCanvasColor(
         Canvas,
-        ((IsFriend != 0 || FHUDMutator.ForceShowAsFriend) && HUDConfig.FriendNameColorEnabled)
+        ((IsFriend != 0 || FHUD.ForceShowAsFriend) && HUDConfig.FriendNameColorEnabled)
             ? HUDConfig.FriendNameColor
             : HUDConfig.NameColor
     );
@@ -1535,7 +1535,7 @@ function bool DrawHealthBarItem(Canvas Canvas, const out PlayerItemInfo ItemInfo
 
         if (ManualModeCurrentPRI.KFPRI == ItemInfo.KFPRI)
         {
-            class'FriendlyHUD.FriendlyHUDHelper'.static.DrawSelection(
+            class'FriendlyHUDHelper'.static.DrawSelection(
                 Canvas,
                 SelectionPosX,
                 SelectionPosY,
@@ -1832,7 +1832,7 @@ function DrawBar(
 
         if (HUDConfig.DrawDebugRatios)
         {
-            DebugRatioText = class'FriendlyHUD.FriendlyHUDHelper'.static.FloatToString(P1 * BlockRatio, 2) $ "/" $ class'FriendlyHUD.FriendlyHUDHelper'.static.FloatToString(BlockRatio, 2);
+            DebugRatioText = class'FriendlyHUDHelper'.static.FloatToString(P1 * BlockRatio, 2) $ "/" $ class'FriendlyHUDHelper'.static.FloatToString(BlockRatio, 2);
             SetCanvasColor(Canvas, MakeColor(202, 44, 146, 255));
             Canvas.TextSize(DebugRatioText, DebugRatioWidth, DebugRatioHeight, 0.6f, 0.6f);
             Canvas.SetPos(BlockOffsetX + CurrentBlockPosX, BlockOffsetY + CurrentBlockPosY + CurrentBlockHeight - DebugRatioHeight);

--- a/Classes/FriendlyHUDMutator.uc
+++ b/Classes/FriendlyHUDMutator.uc
@@ -1,404 +1,66 @@
 class FriendlyHUDMutator extends KFMutator;
 
-// Server-only
-var FriendlyHUDCDCompatController CDCompat;
+var FriendlyHUD FriendlyHUD;
 
-// Replicated
-var FriendlyHUDReplicationInfo RepInfo;
-var bool UMLoaded, CDReadyEnabled;
-
-// Client-only
-var KFPlayerController KFPC;
-var KFGFxHudWrapper HUD;
-var FriendlyHUDInteraction FHUDInteraction;
-var FriendlyHUDConfig HUDConfig;
-
-var bool ForceShowAsFriend;
-var int PriorityCount;
-
-struct ClikKeyModifiers
+function bool SafeDestroy()
 {
-    var bool Ctrl;
-    var bool Alt;
-    var bool Shift;
-};
-
-var GFxClikWidget HUDChatInputField, PartyChatInputField;
-var const ClikKeyModifiers UnsetKeyModifiers;
-var ClikKeyModifiers KeyModifiers;
-
-const HelpURL = "https://steamcommunity.com/sharedfiles/filedetails/?id=1827646464";
-const WhatsNewURL = "https://steamcommunity.com/sharedfiles/filedetails/?id=1871444075";
-const GFxListenerPriority = 80000;
-
-replication
-{
-    if (bNetDirty)
-        RepInfo, UMLoaded, CDReadyEnabled;
+    return (bPendingDelete || bDeleteMe || Destroy());
 }
 
-simulated event PostBeginPlay()
+event PreBeginPlay()
 {
-    super.PostBeginPlay();
+    Super.PreBeginPlay();
 
-    if (bDeleteMe) return;
+    if (WorldInfo.NetMode == NM_Client) return;
 
-    `Log("[FriendlyHUD] Loaded mutator");
-
-    if (Role == ROLE_Authority)
+    foreach WorldInfo.DynamicActors(class'FriendlyHUD', FriendlyHUD)
     {
-        UMLoaded = IsUMLoaded();
-
-        RepInfo = Spawn(class'FriendlyHUD.FriendlyHUDReplicationInfo', Self);
-        RepInfo.FHUDMutator = Self;
-        RepInfo.HUDConfig = HUDConfig;
-
-        CDCompat = Spawn(class'FriendlyHUD.FriendlyHUDCDCompatController', Self);
-        CDCompat.FHUDMutator = Self;
-
-        SetTimer(2.f, true, nameof(CheckBots));
+        break;
     }
 
-    if (WorldInfo.NetMode != NM_DedicatedServer)
+    if (FriendlyHUD == None)
     {
-        InitializeHUD();
+        FriendlyHUD = WorldInfo.Spawn(class'FriendlyHUD');
+    }
+
+    if (FriendlyHUD == None)
+    {
+        `Log("[FriendlyHUD] Can't Spawn 'FriendlyHUD'");
+        SafeDestroy();
     }
 }
 
-simulated event Destroyed()
+function AddMutator(Mutator Mut)
 {
-    if (WorldInfo.NetMode != NM_DedicatedServer)
-    {
-        KFPC.ConsoleCommand("exec cfg/OnUnloadFHUD.cfg", false);
-    }
+    if (Mut == Self) return;
 
-    super.Destroyed();
-}
-
-simulated function InitializeHUD()
-{
-    `Log("[FriendlyHUD] Initializing");
-
-    KFPC = KFPlayerController(GetALocalPlayerController());
-
-    if (KFPC == None || RepInfo == None)
-    {
-        SetTimer(0.5f, false, nameof(InitializeHUD));
-        return;
-    }
-
-    `Log("[FriendlyHUD] Found KFPC");
-
-    // Initialize the HUD configuration
-    HUDConfig = new (KFPC) class'FriendlyHUD.FriendlyHUDConfig';
-    HUDConfig.FHUDMutator = Self;
-    HUDConfig.KFPlayerOwner = KFPC;
-    KFPC.Interactions.AddItem(HUDConfig);
-    HUDConfig.Initialized();
-
-    // Give a chance for other mutators to initialize
-    SetTimer(2.f, false, nameof(InitializeDeferred));
-}
-
-simulated function InitializeDeferred()
-{
-    HUD = KFGFxHudWrapper(KFPC.myHUD);
-    if (HUD == None)
-    {
-        `Log("[FriendlyHUD] Incompatible HUD detected; aborting.");
-        return;
-    }
-
-    // Initialize the HUD interaction
-    FHUDInteraction = new (KFPC) class'FriendlyHUD.FriendlyHUDInteraction';
-    FHUDInteraction.FHUDMutator = Self;
-    FHUDInteraction.KFPlayerOwner = KFPC;
-    FHUDInteraction.HUD = HUD;
-    FHUDInteraction.HUDConfig = HUDConfig;
-    KFPC.Interactions.InsertItem(0, FHUDInteraction);
-    FHUDInteraction.Initialized();
-    HUDConfig.FHUDInteraction = FHUDInteraction;
-
-    InitializePartyChatHook();
-    InitializeHUDChatHook();
-    InitializeCompat();
-
-    if (IsUMLoaded())
-    {
-        // Defer the printing because we want our message to show up last
-        SetTimer(1.f, false, nameof(PrintNotification));
-    }
+    if (Mut.Class == Class)
+        FriendlyHUDMutator(Mut).SafeDestroy();
     else
-    {
-        PrintNotification();
-    }
-
-    KFPC.ConsoleCommand("exec cfg/OnLoadFHUD.cfg", false);
-
-    `Log("[FriendlyHUD] Initialized");
+        Super.AddMutator(Mut);
 }
 
-simulated function bool IsUMLoaded()
+function NotifyLogin(Controller C)
 {
-    local Mutator Mut;
+    FriendlyHUD.NotifyLogin(C);
 
-    if (Role != ROLE_Authority)
-    {
-        return UMLoaded;
-    }
-
-    for (Mut = WorldInfo.Game.BaseMutator; Mut != None; Mut = Mut.NextMutator)
-    {
-        if (PathName(Mut.class) ~= "UnofficialMod.UnofficialModMut") return true;
-    }
-
-    return false;
+    Super.NotifyLogin(C);
 }
 
-simulated function InitializeCompat()
+function NotifyLogout(Controller C)
 {
-    local UMCompatInteraction UMInteraction;
+    FriendlyHUD.NotifyLogout(C);
 
-    if (!IsUMLoaded()) return;
-
-    `Log("[FriendlyHUD] UnofficialMod detected");
-
-    HUDConfig.InitUMCompat();
-
-    UMInteraction = new (KFPC) class'FriendlyHUD.UMCompatInteraction';
-    UMInteraction.KFPlayerOwner = KFPC;
-    UMInteraction.HUD = HUD;
-    UMInteraction.HUDConfig = HUDConfig;
-    KFPC.Interactions.AddItem(UMInteraction);
-    UMInteraction.Initialized();
+    Super.NotifyLogout(C);
 }
 
-simulated delegate OnHUDChatInputKeyDown(GFxClikWidget.EventData Data)
+// Used to tell SML which class to spawn instead of KFMutator
+static function String GetLocalString(optional int Switch, optional PlayerReplicationInfo RelatedPRI_1, optional PlayerReplicationInfo RelatedPRI_2)
 {
-    if (OnChatKeyDown(HUDChatInputField, Data))
-    {
-        // "Enter" doesn't do anything when it gets pressed too quickly
-        // after opening the chat, so we close it here just in case
-        HUD.HUDMovie.HudChatBox.ClearAndCloseChat();
-    }
-}
-
-simulated delegate OnPartyChatInputKeyDown(GFxClikWidget.EventData Data)
-{
-    OnChatKeyDown(PartyChatInputField, Data);
-}
-
-simulated delegate OnChatFocusIn(GFxClikWidget.EventData Data)
-{
-    KeyModifiers = UnsetKeyModifiers;
-}
-
-simulated delegate OnChatFocusOut(GFxClikWidget.EventData Data)
-{
-    KeyModifiers = UnsetKeyModifiers;
-}
-
-simulated function bool OnChatKeyDown(GFxClikWidget InputField, GFxClikWidget.EventData Data)
-{
-    local GFXObject InputDetails;
-    local int KeyCode;
-    local string EventType;
-    local string KeyEvent;
-    local string Text;
-    local OnlineSubsystem OS;
-    `if(`isdefined(debug))
-    local array<GFxMoviePlayer.ASValue> Params;
-    `endif
-
-    OS = class'GameEngine'.static.GetOnlineSubsystem();
-
-    InputDetails = Data._this.GetObject("details");
-    KeyCode = InputDetails.GetInt("code");
-    EventType = InputDetails.GetString("type");
-    KeyEvent = InputDetails.GetString("value");
-
-    if (EventType != "key") return false;
-
-    `if(`isdefined(debug))
-    `Log("[FriendlyHUD] OnKeyDown:" @ Data._this.Invoke("toString", Params).s);
-    `endif
-
-    // CTRL
-    if (KeyCode == 17)
-    {
-        KeyModifiers.Ctrl = KeyEvent != "keyUp";
-        return false;
-    }
-
-    // ALT
-    if (KeyCode == 18)
-    {
-        KeyModifiers.Alt = KeyEvent != "keyUp";
-        return false;
-    }
-
-    // SHIFT
-    if (KeyCode == 16)
-    {
-        KeyModifiers.Shift = KeyEvent != "keyUp";
-        return false;
-    }
-
-    // Enter
-    // Note: the "keyHold" event gets triggered when the chat was opened with a key other than "Enter".
-    //       If the chat was opened with "Enter", the event will be "keyDown" instead.
-    if (KeyCode == 13 && (KeyEvent == "keyHold" || KeyEvent == "keyDown"))
-    {
-        Text = InputField.GetText();
-        switch (Locs(Text))
-        {
-            case "!fhudhelp":
-                if (OS == None) return false;
-                OS.OpenURL(HelpURL);
-                break;
-            case "!fhudnews":
-            case "!fhudwhatsnew":
-            case "!fhudchangelog":
-                if (OS == None) return false;
-
-                // Update the changelog version so that we stop nagging the user
-                HUDConfig.UpdateChangeLogVersion();
-
-                OS.OpenURL(WhatsNewURL);
-                break;
-            case "!fhudversion":
-                WriteToChat("[FriendlyHUD]" @ HUDConfig.GetVersionInfo(), "B986E9");
-                break;
-            default:
-                return false;
-        }
-
-        // Clear the field before letting the default event handler process it
-        // This prevents the command from showing up in chat
-        InputField.SetText("");
-
-        return true;
-    }
-
-    return false;
-}
-
-simulated function InitializePartyChatHook()
-{
-    // Retry until the HUD is fully initialized
-    if (KFPC.MyGFxManager == None || KFPC.MyGFxManager.PartyWidget == None || KFPC.MYGFxManager.PartyWidget.PartyChatWidget == None)
-    {
-        `Log("[FriendlyHUD] Failed initializing party chat hook; retrying.");
-        SetTimer(1.f, false, nameof(InitializePartyChatHook));
-        return;
-    }
-
-    // Force the chat to show up in solo
-    KFPC.MyGFxManager.PartyWidget.PartyChatWidget.SetVisible(true);
-
-    PartyChatInputField = GFxClikWidget(KFPC.MyGFxManager.PartyWidget.PartyChatWidget.GetObject("ChatInputField", class'GFxClikWidget'));
-    PartyChatInputField.AddEventListener('CLIK_input', OnPartyChatInputKeyDown, false, GFxListenerPriority, false);
-    PartyChatInputField.AddEventListener('CLIK_focusIn', OnChatFocusIn, false, GFxListenerPriority, false);
-    PartyChatInputField.AddEventListener('CLIK_focusOut', OnChatFocusOut, false, GFxListenerPriority, false);
-
-    `Log("[FriendlyHUD] Initialized party chat hook");
-}
-
-simulated function InitializeHUDChatHook()
-{
-    // Retry until the HUD is fully initialized
-    if (HUD == None || HUD.HUDMovie == None || HUD.HUDMovie.HudChatBox == None)
-    {
-        `if(`isdefined(debug))
-        `Log("[FriendlyHUD] Failed initializing HUD chat hook; retrying.");
-        `endif
-
-        SetTimer(1.f, false, nameof(InitializeHUDChatHook));
-        return;
-    }
-
-    HUDChatInputField = GFxClikWidget(HUD.HUDMovie.HudChatBox.GetObject("ChatInputField", class'GFxClikWidget'));
-    HUDChatInputField.AddEventListener('CLIK_input', OnHUDChatInputKeyDown, false, GFxListenerPriority, false);
-    HUDChatInputField.AddEventListener('CLIK_focusIn', OnChatFocusIn, false, GFxListenerPriority, false);
-    HUDChatInputField.AddEventListener('CLIK_focusOut', OnChatFocusOut, false, GFxListenerPriority, false);
-
-    `Log("[FriendlyHUD] Initialized HUD chat hook");
-}
-
-simulated function WriteToChat(string Message, string HexColor)
-{
-    if (KFPC.MyGFxManager.PartyWidget != None && KFPC.MyGFxManager.PartyWidget.PartyChatWidget != None)
-    {
-        KFPC.MyGFxManager.PartyWidget.PartyChatWidget.AddChatMessage(Message, HexColor);
-    }
-
-    if (HUD != None && HUD.HUDMovie != None && HUD.HUDMovie.HudChatBox != None)
-    {
-        HUD.HUDMovie.HudChatBox.AddChatMessage(Message, HexColor);
-    }
-}
-
-simulated function PrintNotification()
-{
-    if (HUDConfig.ShowHelpNotification)
-    {
-        WriteToChat("[FriendlyHUD] type !FHUDHelp to open the command list.", "B986E9");
-    }
-
-    if (HUDConfig.LastChangeLogVersion < HUDConfig.CurrentVersion)
-    {
-        WriteToChat("[FriendlyHUD] was updated; type !FHUDNews to see the changelog.", "FFFF00");
-    }
-}
-
-simulated function ForceUpdateNameCache()
-{
-    local FriendlyHUDReplicationInfo CurrentRepInfo;
-    local int I;
-
-    CurrentRepInfo = RepInfo;
-    while (CurrentRepInfo != None)
-    {
-        for (I = 0; I < class'FriendlyHUD.FriendlyHUDReplicationInfo'.const.REP_INFO_COUNT; I++)
-        {
-            if (CurrentRepInfo.KFPRIArray[I] == None) continue;
-            CurrentRepInfo.ShouldUpdateNameArray[I] = 1;
-        }
-        CurrentRepInfo = CurrentRepInfo.NextRepInfo;
-    }
-}
-
-function CheckBots()
-{
-    local KFPawn_Human KFPH;
-
-    foreach WorldInfo.AllPawns(class'KFGame.KFPawn_Human', KFPH)
-    {
-        if (KFAIController(KFPH.Controller) != None && !RepInfo.IsPlayerRegistered(KFPH.Controller))
-        {
-            RepInfo.NotifyLogin(KFPH.Controller);
-        }
-    }
-}
-
-function NotifyLogin(Controller NewPlayer)
-{
-    RepInfo.NotifyLogin(NewPlayer);
-
-    super.NotifyLogin(NewPlayer);
-}
-
-function NotifyLogout(Controller Exiting)
-{
-    RepInfo.NotifyLogout(Exiting);
-
-    super.NotifyLogout(Exiting);
+    return String(class'FriendlyHUD');
 }
 
 defaultproperties
 {
-    Role = ROLE_Authority;
-    RemoteRole = ROLE_SimulatedProxy;
-    bAlwaysRelevant = true;
-    PriorityCount = 1;
+
 }

--- a/Classes/UMCompatInteraction.uc
+++ b/Classes/UMCompatInteraction.uc
@@ -1,5 +1,5 @@
 class UMCompatInteraction extends Interaction
-    dependson(FriendlyHUDMutator, FriendlyHUDConfig);
+    dependson(FriendlyHUD, FriendlyHUDConfig);
 
 var KFGFxHudWrapper HUD;
 var KFPlayerController KFPlayerOwner;
@@ -160,7 +160,7 @@ function DrawMedicWeaponRecharge(Canvas Canvas)
 
     MedicWeaponCount = 0;
 
-    ResScale = class'FriendlyHUD.FriendlyHUDHelper'.static.GetResolutionScale(Canvas, false);
+    ResScale = class'FriendlyHUDHelper'.static.GetResolutionScale(Canvas, false);
     IconHeight = default.MedicWeaponHeight * ResScale;
     IconWidth = IconHeight / 2.f;
 


### PR DESCRIPTION
**Add [SML](https://github.com/GenZmeY/KF2-SafeMutLoader) compatibility requested [here](https://github.com/GenZmeY/KF2-SafeMutLoader/issues/9). This allows to use Friendly HUD without losing ranked status**  

- I tried to keep the FHUD code style as much as possible such as indentation with spaces, function/variable modifiers, log output style, etc;  
- the package name has been completely removed from the FriendlyHUD code (`class'FriendlyHUD.<class_name>'` -> `class'<class_name>'`) in case this PR is not accepted and I have to publish a version of FHUD with the package name changed (💀);  
- tested by me and @Stephen720 - it works as expected;
- as a bonus, after recompiling the mutator, the problem of spawning test bots is solved (it doesn't work now).  

There are not as many changes here as it might seem at first glance. Just `FriendlyHUDMutator` was renamed to `FriendlyHUD`, and `FriendlyHUDMutator` was created based on this [template  ](https://github.com/GenZmeY/KF2-SafeMutLoader/blob/master/DEV.md#mutator-template)